### PR TITLE
Osp16 templates kernelargs isol cpus format issue

### DIFF
--- a/osp16_ref/ml2-ovs-nfv.yaml
+++ b/osp16_ref/ml2-ovs-nfv.yaml
@@ -1,7 +1,7 @@
 
 parameter_defaults:
   ComputeOvsDpdkSriovParameters:
-    KernelArgs: "default_hugepagesz=1GB hugepagesz=1G hugepages=32 intel_iommu=on iommu=pt isolcpus=1-11.13-23"
+    KernelArgs: "default_hugepagesz=1GB hugepagesz=1G hugepages=32 intel_iommu=on iommu=pt isolcpus=1-11,13-23"
     IsolCpusList: "1-11,13-23"
     OvsDpdkSocketMemory: "4096"
     OvsDpdkMemoryChannels: "4"


### PR DESCRIPTION
Osp16 templates kernelargs isol cpus format issue fix